### PR TITLE
Fixes for CVR r174, implemented CVRWorld

### DIFF
--- a/CVRLua/Lua/LuaDefs/CVRWorldDefs.cs
+++ b/CVRLua/Lua/LuaDefs/CVRWorldDefs.cs
@@ -1,0 +1,715 @@
+using ABI.CCK.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CVRLua.Lua.LuaDefs
+{
+    static class CVRWorldDefs
+    {
+        const string c_destroyed = "CVRWorld is destroyed";
+
+        static readonly List<(string, LuaInterop.lua_CFunction)> ms_metaMethods = new List<(string, LuaInterop.lua_CFunction)>();
+        static readonly List<(string, (LuaInterop.lua_CFunction, LuaInterop.lua_CFunction))> ms_staticProperties = new List<(string, (LuaInterop.lua_CFunction, LuaInterop.lua_CFunction))>();
+        static readonly List<(string, LuaInterop.lua_CFunction)> ms_staticMethods = new List<(string, LuaInterop.lua_CFunction)>();
+        static readonly List<(string, (LuaInterop.lua_CFunction, LuaInterop.lua_CFunction))> ms_instanceProperties = new List<(string, (LuaInterop.lua_CFunction, LuaInterop.lua_CFunction))>();
+        private static MethodInfo minf_SetupWorldRules;
+
+        internal static void Init()
+        {
+            ms_instanceProperties.Add(("baseMovementSpeed", (GetBaseMovementSpeed, SetBaseMovementSpeed)));
+            ms_instanceProperties.Add(("sprintMultiplier", (GetSprintMultiplier, SetSprintMultiplier)));
+            ms_instanceProperties.Add(("strafeMultiplier", (GetStrafeMultiplier, SetStrafeMultiplier)));
+            ms_instanceProperties.Add(("crouchMultiplier", (GetCrouchMultiplier, SetCrouchMultiplier)));
+            ms_instanceProperties.Add(("proneMultiplier", (GetProneMultiplier, SetProneMultiplier)));
+            ms_instanceProperties.Add(("flyMultiplier", (GetFlyMultiplier, SetFlyMultiplier)));
+            ms_instanceProperties.Add(("inAirMovementMultiplier", (GetInAirMovementMultiplier, SetInAirMovementMultiplier)));
+            ms_instanceProperties.Add(("playerGravity", (GetPlayerGravity, SetPlayerGravity)));
+            ms_instanceProperties.Add(("jumpHeight", (GetJumpHeight, SetJumpHeight)));
+            ms_instanceProperties.Add(("objectGravity", (GetObjectGravity, SetObjectGravity)));
+            ms_instanceProperties.Add(("respawnHeight", (GetRespawnHeight, SetRespawnHeight)));
+            ms_instanceProperties.Add(("allowSpawnables", (GetAllowSpawnables, SetAllowSpawnables)));
+            ms_instanceProperties.Add(("allowPortals", (GetAllowPortals, SetAllowPortals)));
+            ms_instanceProperties.Add(("allowFlying", (GetAllowFlying, SetAllowFlying)));
+            ms_instanceProperties.Add(("allowZoom", (GetAllowZoom, SetAllowZoom)));
+            ms_instanceProperties.Add(("showNameplates", (GetShowNameplates, SetShowNameplates)));
+
+
+            MonoBehaviourDefs.InheritTo(ms_metaMethods, ms_staticProperties, ms_staticMethods, ms_instanceProperties, null);
+        }
+
+        internal static void RegisterInVM(LuaVM p_vm)
+        {
+            p_vm.RegisterClass(typeof(CVRWorld), null, ms_staticProperties, ms_staticMethods, ms_metaMethods, ms_instanceProperties, null);
+            p_vm.RegisterFunction(nameof(IsCVRWorld), IsCVRWorld);
+        }
+
+        // Static methods
+        static int IsCVRWorld(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadNextObject(ref l_world);
+            l_argReader.PushBoolean(l_world != null);
+            return l_argReader.GetReturnValue();
+        }
+
+        // Instance properties
+        static int GetBaseMovementSpeed(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.baseMovementSpeed);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetBaseMovementSpeed(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_baseMovementSpeed = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_baseMovementSpeed);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetBaseMovementSpeed(l_baseMovementSpeed);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetSprintMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.sprintMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetSprintMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_sprintMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_sprintMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetSprintMultiplier(l_sprintMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetStrafeMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.strafeMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetStrafeMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_strafeMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_strafeMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetStrafeMultiplier(l_strafeMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetCrouchMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.crouchMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetCrouchMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_crouchMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_crouchMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetCrouchMultiplier(l_crouchMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetProneMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.proneMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetProneMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_proneMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_proneMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetProneMultiplier(l_proneMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetFlyMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.flyMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetFlyMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_flyMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_flyMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetFlyMultiplier(l_flyMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetInAirMovementMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.inAirMovementMultiplier);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetInAirMovementMultiplier(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_inAirMovementMultiplier = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_inAirMovementMultiplier);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetInAirMovementMultiplier(l_inAirMovementMultiplier);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetPlayerGravity(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.gravity);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetPlayerGravity(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_gravity = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_gravity);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetGravity(l_gravity);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetJumpHeight(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.jumpHeight);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetJumpHeight(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_height = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_height);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetJumpHeight(l_height);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetObjectGravity(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushNumber(l_world.objectGravity);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetObjectGravity(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            float l_gravity = 0f;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadNumber(ref l_gravity);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_world.SetObjectGravity(l_gravity);
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetRespawnHeight(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushInteger(l_world.respawnHeightY);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetRespawnHeight(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            int l_height = -25;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadInteger(ref l_height);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.respawnHeightY = l_height;
+                    l_world.ApplyMovementSettings();
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetAllowSpawnables(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushBoolean(l_world.allowSpawnables);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetAllowSpawnables(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            bool l_allowSpawnables = false;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadBoolean(ref l_allowSpawnables);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.allowSpawnables = l_allowSpawnables;
+                    if (minf_SetupWorldRules == null)
+                        minf_SetupWorldRules = typeof(CVRWorld).GetMethod("SetupWorldRules", BindingFlags.NonPublic | BindingFlags.Instance);
+                    minf_SetupWorldRules.Invoke(l_world, null);
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetAllowPortals(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushBoolean(l_world.allowPortals);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetAllowPortals(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            bool l_allowPortals = false;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadBoolean(ref l_allowPortals);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.allowPortals = l_allowPortals;
+                    if (minf_SetupWorldRules == null)
+                        minf_SetupWorldRules = typeof(CVRWorld).GetMethod("SetupWorldRules", BindingFlags.NonPublic | BindingFlags.Instance);
+                    minf_SetupWorldRules.Invoke(l_world, null);
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetAllowFlying(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushBoolean(l_world.allowFlying);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetAllowFlying(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            bool l_allowFlying = false;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadBoolean(ref l_allowFlying);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.allowFlying = l_allowFlying;
+                    if (minf_SetupWorldRules == null)
+                        minf_SetupWorldRules = typeof(CVRWorld).GetMethod("SetupWorldRules", BindingFlags.NonPublic | BindingFlags.Instance);
+                    minf_SetupWorldRules.Invoke(l_world, null);
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetAllowZoom(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushBoolean(l_world.enableZoom);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetAllowZoom(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            bool l_allowZoom = false;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadBoolean(ref l_allowZoom);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.enableZoom = l_allowZoom;
+                    if (minf_SetupWorldRules == null)
+                        minf_SetupWorldRules = typeof(CVRWorld).GetMethod("SetupWorldRules", BindingFlags.NonPublic | BindingFlags.Instance);
+                    minf_SetupWorldRules.Invoke(l_world, null);
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+        static int GetShowNameplates(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            l_argReader.ReadObject(ref l_world);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                    l_argReader.PushBoolean(l_world.showNamePlates);
+                else
+                {
+                    l_argReader.SetError(c_destroyed);
+                    l_argReader.PushBoolean(false);
+                }
+            }
+            else
+                l_argReader.PushBoolean(false);
+
+            l_argReader.LogError();
+            return 1;
+        }
+        static int SetShowNameplates(IntPtr p_state)
+        {
+            var l_argReader = new LuaArgReader(p_state);
+            CVRWorld l_world = null;
+            bool l_showNameplates = false;
+            l_argReader.ReadObject(ref l_world);
+            l_argReader.ReadBoolean(ref l_showNameplates);
+            if (!l_argReader.HasErrors())
+            {
+                if (l_world != null)
+                {
+                    l_world.showNamePlates = l_showNameplates;
+                    if (minf_SetupWorldRules == null)
+                        minf_SetupWorldRules = typeof(CVRWorld).GetMethod("SetupWorldRules", BindingFlags.NonPublic | BindingFlags.Instance);
+                    minf_SetupWorldRules.Invoke(l_world, null);
+                    ABI_RC.Core.Player.CVRPlayerManager.Instance.ReloadAllNameplates();
+                }
+                else
+                    l_argReader.SetError(c_destroyed);
+            }
+
+            l_argReader.LogError();
+            return 0;
+        }
+    }
+}

--- a/CVRLua/LuaHandler.cs
+++ b/CVRLua/LuaHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace CVRLua
@@ -114,6 +114,7 @@ namespace CVRLua
             Lua.LuaDefs.CVRPointerDefs.Init();
             Lua.LuaDefs.CVRVideoPlayerDefs.Init();
             Lua.LuaDefs.CVRInteractableDefs.Init();
+            Lua.LuaDefs.CVRWorldDefs.Init();
             Lua.LuaDefs.CVRPickupObjectDefs.Init();
 
             // Own defs
@@ -192,6 +193,7 @@ namespace CVRLua
             Lua.LuaDefs.CVRMirrorDefs.RegisterInVM(m_vm);
             Lua.LuaDefs.CVRPointerDefs.RegisterInVM(m_vm);
             Lua.LuaDefs.CVRVideoPlayerDefs.RegisterInVM(m_vm);
+            Lua.LuaDefs.CVRWorldDefs.RegisterInVM(m_vm);
             Lua.LuaDefs.CVRInteractableDefs.RegisterInVM(m_vm);
             Lua.LuaDefs.CVRPickupObjectDefs.RegisterInVM(m_vm);
 

--- a/CVRLua/Main.cs
+++ b/CVRLua/Main.cs
@@ -1,4 +1,4 @@
-﻿using ABI.CCK.Components;
+using ABI.CCK.Components;
 using ABI_RC.Core.InteractionSystem;
 using System;
 using System.Collections.Generic;
@@ -8,7 +8,7 @@ namespace CVRLua
 {
     public class Core : MelonLoader.MelonMod
     {
-        public const int c_modRelease = 33;
+        public const int c_modRelease = 34;
 
         static public Core Instance { get; private set; } = null;
         internal static MelonLoader.MelonLogger.Instance Logger = null;

--- a/CVRLua/Players/Player.cs
+++ b/CVRLua/Players/Player.cs
@@ -1,4 +1,4 @@
-﻿using ABI.CCK.Components;
+using ABI.CCK.Components;
 using ABI_RC.Core;
 using ABI_RC.Core.InteractionSystem;
 using ABI_RC.Core.Player;
@@ -6,7 +6,7 @@ using ABI_RC.Core.Savior;
 using ABI_RC.Systems.IK;
 using ABI_RC.Systems.IK.SubSystems;
 using ABI_RC.Systems.InputManagement;
-using ABI_RC.Systems.MovementSystem;
+using MovementSystem = ABI_RC.Systems.Movement.BetterBetterCharacterController;
 using UnityEngine;
 
 namespace CVRLua.Players
@@ -264,7 +264,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = MovementSystem.Instance.flying;
+                    l_result = MovementSystem.Instance.IsFlying();
                     break;
                 case PlayerType.Remote:
                     l_result = m_puppetMaster.PlayerAvatarMovementDataInput.AnimatorFlying;
@@ -309,7 +309,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = MovementSystem.Instance.sitting;
+                    l_result = MovementSystem.Instance.IsSitting();
                     break;
                 case PlayerType.Remote:
                     l_result = m_puppetMaster.PlayerAvatarMovementDataInput.AnimatorSitting;
@@ -364,8 +364,8 @@ namespace CVRLua.Players
             {
                 case PlayerType.Local:
                 {
-                    l_result.x = MovementSystem.Instance.movementVector.x;
-                    l_result.y = MovementSystem.Instance.movementVector.y;
+                    l_result.x = MovementSystem.Instance.AppliedMovementVector.x;
+                    l_result.y = MovementSystem.Instance.AppliedMovementVector.y;
                 }
                 break;
                 case PlayerType.Remote:
@@ -384,7 +384,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = IKSystem.Instance.leftHandOffset.position;
+                    l_result = IKSystem.Instance.leftHandTarget.position;
                     break;
                 case PlayerType.Remote:
                 {
@@ -407,7 +407,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = IKSystem.Instance.leftHandOffset.rotation;
+                    l_result = IKSystem.Instance.leftHandRotations.rotation;
                     break;
                 case PlayerType.Remote:
                 {
@@ -430,7 +430,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = IKSystem.Instance.rightHandOffset.position;
+                    l_result = IKSystem.Instance.rightHandTarget.position;
                     break;
                 case PlayerType.Remote:
                 {
@@ -453,7 +453,7 @@ namespace CVRLua.Players
             switch(m_type)
             {
                 case PlayerType.Local:
-                    l_result = IKSystem.Instance.rightHandOffset.rotation;
+                    l_result = IKSystem.Instance.rightHandRotations.rotation;
                     break;
                 case PlayerType.Remote:
                 {
@@ -503,13 +503,13 @@ namespace CVRLua.Players
         public void Teleport(Vector3 p_position)
         {
             if(m_type == PlayerType.Local)
-                MovementSystem.Instance.TeleportTo(p_position);
+                MovementSystem.Instance.TeleportPosition(p_position);
         }
 
         public void Teleport(Vector3 p_position, Quaternion p_rotation)
         {
             if(m_type == PlayerType.Local)
-                MovementSystem.Instance.TeleportTo(p_position, p_rotation.eulerAngles);
+                MovementSystem.Instance.TeleportPlayerTo(p_position, true, false, p_rotation);
         }
 
         public void SetImmobilized(bool p_state)
@@ -595,7 +595,7 @@ namespace CVRLua.Players
                     l_result = CVRInputManager.Instance.individualFingerTracking;
                     break;
                 case PlayerType.Remote:
-                    l_result = m_puppetMaster.PlayerAvatarMovementDataInput.IndexUseIndividualFingers;
+                    l_result = m_puppetMaster.PlayerAvatarMovementDataInput.UseIndividualFingers;
                     break;
             }
             return l_result;
@@ -610,16 +610,16 @@ namespace CVRLua.Players
                 {
                     l_result = new float[10]
                     {
-                        CVRInputManager.Instance.fingerCurlLeftThumb,
-                        CVRInputManager.Instance.fingerCurlLeftIndex,
-                        CVRInputManager.Instance.fingerCurlLeftMiddle,
-                        CVRInputManager.Instance.fingerCurlLeftThumb,
-                        CVRInputManager.Instance.fingerCurlLeftPinky,
-                        CVRInputManager.Instance.fingerCurlRightThumb,
-                        CVRInputManager.Instance.fingerCurlRightIndex,
-                        CVRInputManager.Instance.fingerCurlRightMiddle,
-                        CVRInputManager.Instance.fingerCurlRightThumb,
-                        CVRInputManager.Instance.fingerCurlRightPinky
+                        CVRInputManager.Instance.fingerFullCurlNormalizedLeftThumb,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedLeftIndex,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedLeftMiddle,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedLeftThumb,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedLeftPinky,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedRightThumb,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedRightIndex,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedRightMiddle,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedRightThumb,
+                        CVRInputManager.Instance.fingerFullCurlNormalizedRightPinky
                     };
                 }
                 break;
@@ -627,16 +627,16 @@ namespace CVRLua.Players
                 {
                     l_result = new float[10]
                     {
-                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftThumbCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftIndexCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftMiddleCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftRingCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftPinkyCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.RightThumbCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.RightIndexCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.RightMiddleCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.RightRingCurl,
-                        m_puppetMaster.PlayerAvatarMovementDataInput.RightPinkyCurl
+                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftThumbSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftIndexSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftMiddleSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftRingSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.LeftPinkySpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.RightThumbSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.RightIndexSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.RightMiddleSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.RightRingSpread,
+                        m_puppetMaster.PlayerAvatarMovementDataInput.RightPinkySpread
                     };
                 }
                 break;

--- a/CVRLua/Players/PlayersManager.cs
+++ b/CVRLua/Players/PlayersManager.cs
@@ -1,10 +1,10 @@
-﻿using ABI_RC.Core.Player;
+using ABI_RC.Core.Player;
 using ABI_RC.Core.Savior;
 using System.Collections.Generic;
 using UnityEngine;
 using ABI_RC.Systems.GameEventSystem;
 using System;
-using ABI_RC.Systems.MovementSystem;
+using MovementSystem = ABI_RC.Systems.Movement.BetterBetterCharacterController;
 
 namespace CVRLua.Players
 {
@@ -91,7 +91,7 @@ namespace CVRLua.Players
         {
             Player l_result = null;
             Transform l_root = p_obj.transform.root;
-            if(l_root == PlayerSetup.Instance.transform || l_root == MovementSystem.Instance.proxyCollider.transform || l_root == MovementSystem.Instance.forceCollider.transform)
+            if(l_root == PlayerSetup.Instance.transform || l_root == MovementSystem.Instance.Collider.transform)
                 l_result = ms_localPlayer;
             else
             {

--- a/CVRLua/Utils.cs
+++ b/CVRLua/Utils.cs
@@ -1,7 +1,7 @@
-﻿using ABI.CCK.Components;
+using ABI.CCK.Components;
 using ABI_RC.Core.Player;
 using ABI_RC.Core.Player.AvatarTracking.Remote;
-using ABI_RC.Systems.MovementSystem;
+using MovementSystem = ABI_RC.Systems.Movement.BetterBetterCharacterController;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
CVRWorld is a brand new implemented class with the following properties:
- ``baseMovementSpeed``: get/set, float
- ``sprintMultiplier``: get/set, float
- ``strafeMultiplier``: get/set, float
- ``crouchMultiplier``: get/set, float
- ``proneMultiplier``: get/set, float
- ``flyMultiplier``: get/set, float
- ``inAirMovementMultiplier``: get/set, float
- ``playerGravity``: get/set, float
- ``jumpHeight``: get/set, float
- ``objectGravity``: get/set, float
- ``respawnHeight``: get/set, integer
- ``allowSpawnables``: get/set, boolean
- ``allowPortals``: get/set, boolean
- ``allowFlying``: get/set, boolean
- ``allowZoom``: get/set, boolean
- ``showNameplated``: get/set, boolean

All modified values update live for players, allowing for some more immersive world functionality.